### PR TITLE
Add per-game save functionality

### DIFF
--- a/Save-Game-Copier/backends/README.md
+++ b/Save-Game-Copier/backends/README.md
@@ -1,0 +1,60 @@
+# Backends
+Save Game Copier (SGC) currently supports the following backends to read\write save game files to:
+* internal\cartridge\external (Floppy) (saturn.c)
+* Action Replay Cartridge (actionreplay.c)
+* CD (cd.c)
+* MODE (mode.c)
+* Satiator (satiator.c)
+
+# Adding a New Backend
+To be compatible with SGC, each new backend must support the following :
+* safe detection of backend device
+* change directory to /SATSAVES
+* directory listing
+* query file size
+* read file
+* write file (optional)
+* delete file (optional)
+* format device (optional)
+* GPL3 or compatible license
+
+## Backup.h
+Edit backup.h adding a new #define for the new backup device. ActionReplayBackup is currently the last one.
+
+## Backend Specific Source
+Create a mybackend.h and mybackend.c. See saturn.h and saturn.c as examples. The file must have the following functions:
+
+* bool mydeviceIsBackupDeviceAvailable(int backupDevice)
+  * returns true if the backup device is present. Should be safe to call when the device isn't present.
+* int mydeviceListSaveFiles(int backupDevice, PSAVES saves, unsigned int numSaves)
+  * queries the saves on the backup device and fills out the fileSaves array. Returns the number of saves found.
+* int mydeviceReadSaveFile(int backupDevice, char* filename, unsigned char* outBuffer, unsigned int outBufSize)
+  * reads the save to outBuffer
+* (optional) int mydeviceWriteSaveFile(int backupDevice, char* filename, unsigned char* saveData, unsigned int saveDataLen)
+  * writes the save file
+* (optional) int mydeviceDeleteSaveFile(int backupDevice, char* filename)
+  * deletes the specified file
+
+## Backend.c
+Edit backend.c adding the new device to the switch statements for isBackupDeviceAvailalbe(), listSaveFiles(), readSaveFile(), writeSaveFile() (optional), deleteSaveFile() optional, and formatDevice() (optional).
+
+Update getBackupDeviceName() to return the name of your device.
+
+## Main.h
+Add a #define MAIN_OPTION_MY_DEVICE. If your device is writeable, add a SAVE_OPTION_MY_DEVICE #define as well.
+
+In the _GAME struct, add a bool deviceMyDeviceBackup member.
+
+## Main.c
+Add your device to queryBackupDevices(). g_Game.deviceMyDeviceBackup = isBackupDeviceAvailable(MyDeviceBackup).
+
+Edit initMenuOptions() adding your device under STATE_MAIN, STATE_DISPLAY_SAVE (if your device is writeable), and STATE_FORMAT (if your device is formatable).
+
+Edit main_input(), add a MAIN_OPTION_MY_DEVICE case.
+
+Edit listSaves_draw() add a your device to the check.
+
+Edit displaySave_input(), adding a case statement for your device.
+
+## Makefile
+Update the makefile

--- a/Save-Game-Copier/backends/backend.c
+++ b/Save-Game-Copier/backends/backend.c
@@ -1,0 +1,293 @@
+#include "backend.h"
+#include "saturn.h"
+//#include "actionreplay.h"
+//#include "mode.h"
+#include "satiator.h"
+//#include "cd.h"
+
+// returns true if the backup device is found
+bool isBackupDeviceAvailable(int backupDevice)
+{
+    switch(backupDevice)
+    {
+        case JoInternalMemoryBackup:
+        case JoCartridgeMemoryBackup:
+        case JoExternalDeviceBackup:
+            return saturnIsBackupDeviceAvailable(backupDevice);
+
+        //case ActionReplayBackup:
+        //    return actionReplayIsBackupDeviceAvailable(backupDevice);
+
+        case SatiatorBackup:
+            return satiatorIsBackupDeviceAvailable(backupDevice);
+
+        //case MODEBackup:
+        //    return modeIsBackupDeviceAvailable(backupDevice);
+
+        //case CdMemoryBackup:
+        //    return true; // always assume CD backups are available
+
+        default:
+            //displayStatus("Invalid backup device specified!! %d\n", backupDevice);
+            return -1;
+    }
+
+    return -1;
+}
+
+// queries the saves on the backup device and fills out the saves array
+int listSaveFiles(int backupDevice, PSAVES saves, unsigned int numSaves)
+{
+    switch(backupDevice)
+    {
+        case JoInternalMemoryBackup:
+        case JoCartridgeMemoryBackup:
+        case JoExternalDeviceBackup:
+            return saturnListSaveFiles(backupDevice, saves, numSaves);
+
+        //case ActionReplayBackup:
+        //    return actionReplayListSaveFiles(backupDevice, saves, numSaves);
+
+        case SatiatorBackup:
+            return satiatorListSaveFiles(backupDevice, saves, numSaves);
+
+        //case MODEBackup:
+        //    return modeListSaveFiles(backupDevice, saves, numSaves);
+
+        //case CdMemoryBackup:
+        //    return cdListSaveFiles(backupDevice, saves, numSaves);
+
+        default:
+            //displayStatus("Invalid backup device specified!! %d\n", backupDevice);
+            return -1;
+    }
+
+    return -1;
+}
+
+// reads the specified save game from the backup device
+int readSaveFile(int backupDevice, char* filename, unsigned char* outBuffer, unsigned int outSize)
+{
+    switch(backupDevice)
+    {
+        case JoInternalMemoryBackup:
+        case JoCartridgeMemoryBackup:
+        case JoExternalDeviceBackup:
+            return saturnReadSaveFile(backupDevice, filename, outBuffer, outSize);
+
+        //case ActionReplayBackup:
+        //    return actionReplayReadSaveFile(backupDevice, filename, outBuffer, outSize);
+
+        case SatiatorBackup:
+            return satiatorReadSaveFile(backupDevice, filename, outBuffer, outSize);
+
+        //case MODEBackup:
+        //    return modeReadSaveFile(backupDevice, filename, outBuffer, outSize);
+
+        //case CdMemoryBackup:
+        //    return cdReadSaveFile(backupDevice, filename, outBuffer, outSize);
+
+        default:
+            //displayStatus("Invalid backup device specified!! %d\n", backupDevice);
+            return -1;
+    }
+
+    return -1;
+}
+
+// write the save game to the backup device
+int writeSaveFile(int backupDevice, char* filename, unsigned char* inBuffer, unsigned int inSize)
+{
+    switch(backupDevice)
+    {
+        case JoInternalMemoryBackup:
+        case JoCartridgeMemoryBackup:
+        case JoExternalDeviceBackup:
+            return saturnWriteSaveFile(backupDevice, filename, inBuffer, inSize);
+
+        case SatiatorBackup:
+            return satiatorWriteSaveFile(backupDevice, filename, inBuffer, inSize);
+
+        //case MODEBackup:
+        //    return modeWriteSaveFile(backupDevice, filename, inBuffer, inSize);
+
+        //case CdMemoryBackup:
+        //    return -1;
+
+        default:
+            //displayStatus("Invalid backup device specified!! %d\n", backupDevice);
+            return -1;
+    }
+}
+
+// delete the save from the backup device
+int deleteSaveFile(int backupDevice, char* filename)
+{
+    switch(backupDevice)
+    {
+        case JoInternalMemoryBackup:
+        case JoCartridgeMemoryBackup:
+        case JoExternalDeviceBackup:
+            return saturnDeleteSaveFile(backupDevice, filename);
+
+        case SatiatorBackup:
+            return satiatorDeleteSaveFile(backupDevice, filename);
+
+        //case MODEBackup:
+        //    return modeDeleteSaveFile(backupDevice, filename);
+
+        //case CdMemoryBackup:
+        //    return -1;
+
+        default:
+            //displayStatus("Invalid backup device specified!! %d\n", backupDevice);
+            return -1;
+    }
+
+    return -1;
+}
+
+// format a backup device
+int formatDevice(int backupDevice)
+{
+    bool result = false;
+
+    switch(backupDevice)
+    {
+        case JoInternalMemoryBackup:
+        case JoCartridgeMemoryBackup:
+        case JoExternalDeviceBackup:
+            break;
+        default:
+        {
+            //displayStatus("Invalid device to format!!");
+            return -1;
+        }
+    }
+
+    result = jo_backup_mount(backupDevice);
+    if(result == false)
+    {
+        char* deviceName = NULL;
+        getBackupDeviceName(backupDevice, &deviceName);
+
+        //displayStatus("Failed to mount %s!!", deviceName);
+        return -2;
+    }
+
+    result = jo_backup_format_device(backupDevice);
+    if(result == false)
+    {
+        //displayStatus("Failed to format device!!");
+        return -3;
+    }
+
+    return 0;
+}
+
+// get device name from device id
+int getBackupDeviceName(unsigned int backupDevice, char** deviceName)
+{
+    switch(backupDevice)
+    {
+        case JoInternalMemoryBackup:
+            *deviceName = "Internal Memory";
+            break;
+        case JoCartridgeMemoryBackup:
+            *deviceName = "Cartridge Memory";
+            break;
+        case JoExternalDeviceBackup:
+            *deviceName = "External Device";
+            break;
+        case ActionReplayBackup:
+            *deviceName = "Action Replay (Beta Read-Only)";
+            break;
+        case SatiatorBackup:
+            *deviceName = "Satiator";
+            break;
+        case MODEBackup:
+            *deviceName = "MODE";
+            break;
+        case CdMemoryBackup:
+            *deviceName = "CD File System";
+            break;
+        case MemoryBackup:
+            *deviceName = "RAM";
+            break;
+
+        default:
+            //displayStatus("Invalid backup device specified!! %d\n", backupDevice);
+            return -1;
+    }
+
+    return 0;
+}
+
+// check if the filename ends with ".BUP"
+bool isFileBUPExt(char* filename)
+{
+    unsigned int len = 0;
+    char* ext = NULL;
+    int result = 0;
+
+    if(!filename)
+    {
+        //displayStatus("Filename cannot be NULL");
+        return false;
+    }
+
+    len = strlen(filename);
+    if(len < sizeof(BUP_EXTENSION))
+    {
+        return false;
+    }
+
+    ext = &filename[len - strlen(BUP_EXTENSION)];
+    result = strcmp(ext, BUP_EXTENSION);
+    if(result == 0)
+    {
+        return true;
+    }
+
+    return false;
+}
+
+// validates the BUP header and extracts the various fields contained within
+int parseBupHeaderValues(PBUP_HEADER bupHeader, unsigned int totalBupSize, char* saveName, char* saveComment, unsigned char* saveLanguage, unsigned int* saveDate, unsigned int* saveSize, unsigned short* saveBlocks)
+{
+    int result = 0;
+
+    if(!bupHeader || !totalBupSize || !saveName || !saveComment || !saveLanguage || !saveDate || !saveSize || !saveBlocks)
+    {
+        return -1;
+    }
+
+    if(totalBupSize < BUP_HEADER_SIZE)
+    {
+        return -2;
+    }
+
+    result = memcmp(bupHeader->magic, VMEM_MAGIC_STRING, sizeof(bupHeader->magic));
+    if(result != 0)
+    {
+        return -3;
+    }
+
+    if(totalBupSize != bupHeader->dir.datasize + BUP_HEADER_SIZE)
+    {
+       // return -4
+    }
+
+    memcpy(saveName, bupHeader->dir.filename, sizeof(bupHeader->dir.filename));
+    saveName[sizeof(bupHeader->dir.filename) -1] = '\0';
+
+    memcpy(saveComment, bupHeader->dir.comment, sizeof(bupHeader->dir.comment));
+    saveComment[sizeof(bupHeader->dir.comment) -1] = '\0';
+
+    *saveLanguage = bupHeader->dir.language;
+    *saveDate = bupHeader->dir.date;
+    *saveSize = bupHeader->dir.datasize;
+    *saveBlocks = bupHeader->dir.blocksize;
+
+    return 0;
+}

--- a/Save-Game-Copier/backends/backend.h
+++ b/Save-Game-Copier/backends/backend.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <jo/jo.h>
+#include <STRING.H>
+//#include "../util.h"
+#include "../bup_header.h"
+//#include "../../states/routine_states.h"
+//#include "../../debug.h"
+
+#define MAX_SAVE_SIZE           (256 * 1024) // according to Cafe-Alpha this is the maximum size supported by the BIOS
+#define MAX_SAVE_FILENAME       12
+#define MAX_SAVE_COMMENT        11
+#define MAX_FILENAME            32
+#define MAX_SAVES               255
+
+// all devices should standardize on this directory
+// for storing saves
+#define SAVES_DIRECTORY "SATSAVES"
+
+#define SatiatorBackup (JoExternalDeviceBackup + 1)
+#define CdMemoryBackup (SatiatorBackup + 1)
+#define MemoryBackup (CdMemoryBackup + 1)
+#define MODEBackup (MemoryBackup + 1)
+#define ActionReplayBackup (MODEBackup + 1)
+
+// meta data related to save files
+typedef struct  _SAVES {
+    char filename[MAX_FILENAME]; // filename on the medium. Will have .BUP extension on CD FS and ODEs.
+    char name[MAX_SAVE_FILENAME]; // selected save name
+    char comment[MAX_SAVE_COMMENT]; // selected save comment
+    unsigned char language;
+    unsigned int date;
+    unsigned int datasize;
+    unsigned short blocksize;
+} SAVES, *PSAVES;
+
+typedef int (*BACKUP_LIST_FN)(int backupDevice, PSAVES saves, unsigned int numSaves);
+typedef int (*BACKUP_READ_FN)(int backupDevice, char* filename, unsigned char* outBuffer, unsigned int outSize);
+typedef int (*BACKUP_WRITE_FN)(int backupDevice, char* filename, unsigned char* inBuffer, unsigned int inSize);
+typedef int (*BACKUP_DELETE_FN)(int backupDevice, char* filename);
+typedef int (*BACKUP_FORMAT_FN)(int backupDevice);
+
+typedef struct _BACKUP_MEDIUM
+{
+    int backupDevice;
+    char* deviceName;
+
+    BACKUP_LIST_FN listSaveFiles;
+    BACKUP_READ_FN readSaveFile;
+    BACKUP_WRITE_FN writeSaveFile;
+    BACKUP_DELETE_FN deleteSaveFile;
+    BACKUP_FORMAT_FN formatDevice;
+} BACKUP_MEDIUM, *PBACKUP_MEDIUM;
+
+// access the save data
+bool isBackupDeviceAvailable(int backupDevice);
+int listSaveFiles(int backupDevice, PSAVES saves, unsigned int numSaves);
+int readSaveFile(int backupDevice, char* filename, unsigned char* outBuffer, unsigned int outSize);
+int writeSaveFile(int backupDevice, char* filename, unsigned char* inBuffer, unsigned int inSize);
+int deleteSaveFile(int backupDevice, char* filename);
+int formatDevice(int backupDevice);
+
+// helper functions
+int getBackupDeviceName(unsigned int backupDevice, char** deviceName);
+bool isFileBUPExt(char* filename);
+int parseBupHeaderValues(PBUP_HEADER bupHeader, unsigned int totalBupSize, char* saveName, char* saveComment, unsigned char* saveLanguage, unsigned int* saveDate, unsigned int* saveSize, unsigned short* saveBlocks);
+
+// prototypes to keep compiler happy
+int snprintf(char *str, size_t size, const char *format, ...);
+

--- a/Save-Game-Copier/backends/sat.c
+++ b/Save-Game-Copier/backends/sat.c
@@ -1,0 +1,499 @@
+// Saturn Allocation Table (SAT) save partition parsing
+#include <string.h>
+#include "backend.h"
+#include "sat.h"
+
+// given a save size in bytes, calculate how many save blocks are required
+// block size is the size of the block including the 4 byte tag field
+int calcNumBlocks(unsigned int saveSize, unsigned int blockSize, unsigned int* numSaveBlocks)
+{
+    unsigned int totalBytes = 0;
+    unsigned int fixedBytes = 0;
+    unsigned int numBlocks = 0;
+    unsigned int numBlocks2 = 0;
+
+    if(saveSize == 0)
+    {
+        return -1;
+    }
+
+    if(numSaveBlocks == NULL)
+    {
+        return -2;
+    }
+
+    // block size must be 64-byte aligned
+    if((blockSize % 0x40) != 0 || blockSize == 0)
+    {
+        return -3;
+    }
+
+    //
+    // The stored save consists of:
+    // - the save metadata header
+    // - the variable length SAT table
+    // - the save data itself
+    //
+    // What makes this tricky to compute is that the SAT table itself is stored
+    // on the blocks
+    //
+
+    fixedBytes = sizeof(SAT_START_BLOCK_HEADER) - SAT_TAG_SIZE + saveSize;
+
+    // calculate the number of SAT table entries required
+    numBlocks = fixedBytes / (blockSize - SAT_TAG_SIZE);
+
+    // +1 for 0x0000 SAT table terminator
+    totalBytes = fixedBytes + ((numBlocks + 1) * sizeof(unsigned short));
+
+    // we need to do this in a loop because it's possible that by adding a SAT
+    // table entry we increased the number of bytes we need such that we need
+    // yet another SAT table entry.
+    do
+    {
+        numBlocks = numBlocks2;
+        totalBytes = fixedBytes + ((numBlocks + 1) * sizeof(unsigned short));
+        numBlocks2 = totalBytes / (blockSize - SAT_TAG_SIZE);
+
+        if(totalBytes % (blockSize - SAT_TAG_SIZE))
+        {
+            numBlocks2++;
+        }
+
+    }while(numBlocks != numBlocks2);
+
+    *numSaveBlocks = numBlocks;
+
+    return 0;
+}
+
+// find all saves in the partition
+int satListSaves(unsigned char* partitionBuf, unsigned int partitionSize, unsigned int blockSize, PSAVES saves, unsigned int numSaves)
+{
+    PSAT_START_BLOCK_HEADER metadata = NULL;
+    unsigned int savesFound = 0;
+
+    if(partitionBuf == NULL)
+    {
+        //displayStatus("Buffer can't be NULL");
+        return -1;
+    }
+
+    if(partitionSize == 0 || (partitionSize % blockSize) != 0)
+    {
+        //displayStatus("Invalid partition size\n");
+        return -2;
+    }
+
+    for(unsigned int i = 0; i < partitionSize; i += blockSize)
+    {
+        metadata = (PSAT_START_BLOCK_HEADER)(partitionBuf + i);
+
+        // validate range
+        if((unsigned char*)metadata < partitionBuf || (unsigned char*)metadata >= partitionBuf + partitionSize)
+        {
+            //displayStatus("%x %x %x\n", partitionBuf, metadata, partitionSize);
+            return -3;
+        }
+
+        // every save starts with a tag
+        if(metadata->tag == SAT_START_BLOCK_TAG)
+        {
+            // save name
+            // BUGBUG: figure out how to set filename (versus savename)
+            memcpy(saves[savesFound].name, metadata->saveName, MAX_SAVE_FILENAME - 1);
+            memcpy(saves[savesFound].filename, metadata->saveName, MAX_SAVE_FILENAME - 1);
+
+            // langugae
+            saves[savesFound].language = metadata->language;
+            memcpy(saves[savesFound].comment, metadata->comment, MAX_SAVE_COMMENT - 1);
+            saves[savesFound].date = metadata->date;
+            saves[savesFound].datasize = metadata->saveSize;
+
+            // blocksize isn't needed
+            saves[savesFound].blocksize = 0;
+
+            ////displayStatus("%s %d %s %x %d", savename, language, comment, date, saveSize);
+
+            savesFound++;
+
+            // check if we are finished looking for saves
+            if(savesFound >= numSaves)
+            {
+                // no more room in our saves array
+                return savesFound;
+            }
+        }
+    }
+
+    return savesFound;
+}
+
+// locate a save start block based on save name
+int getSaveStartBlock(unsigned char* partitionBuf, unsigned int partitionSize, unsigned int blockSize, char* saveName, PSAT_START_BLOCK_HEADER* metadata)
+{
+    if(partitionBuf == NULL)
+    {
+        return -1;
+    }
+
+    // block size must be 64-byte aligned
+    if((blockSize % 0x40) != 0 || blockSize == 0)
+    {
+        return -2;
+    }
+
+    if(partitionSize == 0 || (partitionSize % blockSize) != 0)
+    {
+        return -3;
+    }
+
+    if(saveName == NULL || metadata == NULL)
+    {
+        return -4;
+    }
+
+    // parse through all blocks looking for a save start tag
+    for(unsigned int i = 0; i < partitionSize; i += blockSize)
+    {
+        *metadata = (PSAT_START_BLOCK_HEADER)(partitionBuf + i);
+
+        // start tag
+        if((*metadata)->tag == SAT_START_BLOCK_TAG)
+        {
+            // found a save
+            (*metadata)->date = (*metadata)->date;
+            (*metadata)->saveSize = (*metadata)->saveSize;
+
+            // found a save start block, check if it's for our game
+            if(strncmp((*metadata)->saveName, saveName, SAT_MAX_SAVE_NAME) == 0)
+            {
+                return 0;
+            }
+        }
+    }
+
+    // save not found
+    return -5;
+}
+
+// returns the SAT blocks on success. Must be freed by caller
+int getSATBlocks(unsigned char* partitionBuf, unsigned int partitionSize, unsigned int blockSize, PSAT_START_BLOCK_HEADER metadata, PSAT_BLOCK* satBlocks)
+{
+    unsigned int numSatBlocks = 0;
+    unsigned int writtenSatEntries = 0;
+    unsigned int curSatTableIndex = 0;
+    unsigned short firstEntry = 0;
+    int result = 0;
+
+    if(partitionBuf == NULL)
+    {
+        return -1;
+    }
+
+    // block size must be 64-byte aligned
+    if((blockSize % 0x40) != 0 || blockSize == 0)
+    {
+        return -2;
+    }
+
+    if(partitionSize == 0 || (partitionSize % blockSize) != 0)
+    {
+        return -3;
+    }
+
+    if(metadata == NULL || satBlocks == NULL)
+    {
+        return -4;
+    }
+
+    result = calcNumBlocks(metadata->saveSize, blockSize, &numSatBlocks);
+    if(result < 0)
+    {
+        return -5;
+    }
+
+    // +1 for the first SAT entry which isn't included
+    numSatBlocks++;
+
+    // check for integer overflow
+    if(numSatBlocks > numSatBlocks * sizeof(SAT_BLOCK))
+    {
+        return -6;
+    }
+
+    *satBlocks = (PSAT_BLOCK)jo_malloc(numSatBlocks * sizeof(SAT_BLOCK));
+    if(*satBlocks == NULL)
+    {
+        return -3;
+    }
+    memset(*satBlocks, 0, numSatBlocks * sizeof(SAT_BLOCK));
+
+    // the first SAT entry isn't written in the SAT blocks array
+    firstEntry = ((unsigned char*)metadata - partitionBuf)/SAT_PARTITION_SIZE;
+
+    (*satBlocks)[0].blockNum = firstEntry;
+    writtenSatEntries = 1;
+
+    // loop through the blocks while we read the SAT table
+    // this is tricky because we are writing to the satBlocks array while parsing it
+    do
+    {
+        // make sure we aren't beyond the end of our array
+        if(curSatTableIndex > writtenSatEntries)
+        {
+            jo_free(*satBlocks);
+            *satBlocks = NULL;
+            return -4;
+        }
+
+        // read SAT table entries from this block
+        result = readSATFromBlock(partitionBuf, partitionSize, blockSize, curSatTableIndex, *satBlocks, numSatBlocks, &writtenSatEntries);
+        if(result < 0)
+        {
+            jo_free(*satBlocks);
+            *satBlocks = NULL;
+            return -5;
+        }
+
+        curSatTableIndex++;
+
+    }while(result != 0);
+
+    // success
+    return 0;
+}
+
+// reads the SAT table from satBlocks[currBlock]
+int readSATFromBlock(unsigned char* partitionBuf, unsigned int partitionSize, unsigned int blockSize, unsigned int currBlock, PSAT_BLOCK satBlocks, unsigned int maxBlocks, unsigned int* numBlocks)
+{
+    PSAT_START_BLOCK_HEADER metadata = NULL;
+    unsigned int startByte = 0;
+
+    if(partitionBuf == NULL)
+    {
+        return -1;
+    }
+
+    // block size must be 64-byte aligned
+    if((blockSize % 0x40) != 0 || blockSize == 0)
+    {
+        return -2;
+    }
+
+    if(partitionSize == 0 || (partitionSize % blockSize) != 0)
+    {
+        return -3;
+    }
+
+    if(satBlocks == NULL)
+    {
+        return -4;
+    }
+
+    if(currBlock >= *numBlocks)
+    {
+        return -5;
+    }
+
+    metadata = (PSAT_START_BLOCK_HEADER)(partitionBuf + (satBlocks[currBlock].blockNum * blockSize));
+
+    // validate we are still in range
+    if(metadata == NULL || (unsigned char*)metadata < partitionBuf || (unsigned char*)metadata >= partitionBuf + partitionSize)
+    {
+        return -6;
+    }
+
+    // first entry
+    if(currBlock == 0)
+    {
+        // first block must have the start tag
+        if(metadata->tag != SAT_START_BLOCK_TAG)
+        {
+            return -1;
+        }
+
+        // flags will be needed for retrieving save data
+        satBlocks[currBlock].flags |= (SAT_START_BLOCK_FLAG | SAT_TABLE_BLOCK_FLAG);
+
+        // where the block's data starts
+        // first block has the PSAT_START_BLOCK_HEADER
+        startByte = sizeof(SAT_START_BLOCK_HEADER);
+    }
+    else
+    {
+        // other blocks must not have the continuation tag
+        if(metadata->tag != SAT_CONTINUE_BLOCK_TAG)
+        {
+            return -1;
+        }
+
+        // flags will be needed for retrieving save data
+        satBlocks[currBlock].flags |= (SAT_TABLE_BLOCK_FLAG);
+
+        // where the block's data starts
+        // continuation block's only have a 4-byte tag field
+        startByte = SAT_TAG_SIZE;
+    }
+
+    // loop through the block, recording SAT table entries until you find the
+    // 0x0000 terminator or reach the end of the block
+    for(startByte; startByte < blockSize; startByte += sizeof(unsigned short))
+    {
+        unsigned short index = *(unsigned short*)((unsigned char*)metadata + startByte);
+
+        // found the last entry
+        if(*numBlocks >= maxBlocks)
+        {
+            return -1;
+        }
+
+        // found a table entry, record it
+        satBlocks[*numBlocks].blockNum = index;
+        ////displayStatus("%x", index);
+        (*numBlocks)++;
+
+        // end index
+        if(index == 0)
+        {
+            // we are at the end index
+            satBlocks[currBlock].flags |= SAT_TABLE_END_BLOCK_FLAG;
+            return 0;
+        }
+    }
+
+    // didn't find end val, continue checking
+    return 1;
+}
+
+// given a SAT table, reads the save to save data
+int getSATSave(unsigned char* partitionBuf, unsigned int partitionSize, unsigned int blockSize, PSAT_BLOCK satBlocks, unsigned char* saveData, unsigned int saveSize)
+{
+    unsigned int bytesWritten = 0;
+    unsigned int bytesToCopy = 0;
+    unsigned int blockDataSize = 0x40 -4;
+    unsigned char* block = NULL;
+
+    if(partitionBuf == NULL)
+    {
+        return -1;
+    }
+
+    // block size must be 64-byte aligned
+    if((blockSize % 0x40) != 0 || blockSize == 0)
+    {
+        return -2;
+    }
+
+    if(partitionSize == 0 || (partitionSize % blockSize) != 0)
+    {
+        return -3;
+    }
+
+    if(satBlocks == NULL)
+    {
+        return -4;
+    }
+
+    if(saveData == NULL || saveSize == 0)
+    {
+        return -5;
+    }
+
+    // Edge cases
+    // - last block isn't necessarily full, need save size for this
+    // - first block contains header, sat table, and possibly data
+    // - the last SAT table block can possibly include data
+
+    while(satBlocks->blockNum)
+    {
+        block = (unsigned char*)(partitionBuf + (satBlocks->blockNum * blockSize));
+
+        // validate we are still in range
+        if(block < partitionBuf || block >= partitionBuf + partitionSize)
+        {
+            return -6;
+        }
+
+        // no flags means we are just a data block (no metadata, no SAT entries)
+        if(satBlocks->flags == 0)
+        {
+            // check if we are the very last block and we aren't full
+            if(saveSize - bytesWritten < blockDataSize)
+            {
+                // last block isn't full, copy less data
+                bytesToCopy = saveSize - bytesWritten;
+            }
+            else
+            {
+                bytesToCopy = blockDataSize;
+            }
+
+            // copy the save bytes
+            memcpy(saveData + bytesWritten, block + SAT_TAG_SIZE, bytesToCopy);
+            bytesWritten += bytesToCopy;
+        }
+
+        // SAT table end means this block contains the last of the SAT blocks. It is possible there is save data here
+        else if(satBlocks->flags & SAT_TABLE_END_BLOCK_FLAG)
+        {
+            unsigned int skipBytes = 0;
+
+            // end of the SAT array, data can follow
+            bytesToCopy = blockDataSize;
+
+            // is this the start block?
+            if(satBlocks->flags & SAT_START_BLOCK_FLAG)
+            {
+                // skip over the header data
+                skipBytes += sizeof(SAT_START_BLOCK_HEADER) - SAT_TAG_SIZE;
+            }
+
+            // This is a SAT table block, parse until the 0x0000 and then start reading save bytes
+            if(satBlocks->flags & SAT_TABLE_BLOCK_FLAG)
+            {
+                // skip over all SAT entries including the terminating 0x0000
+                for(unsigned int i = skipBytes; i < blockDataSize; i += sizeof(unsigned short))
+                {
+                    unsigned short satIndex = *(unsigned short*)(block + i + SAT_TAG_SIZE);
+
+                    if(satIndex == 0)
+                    {
+                        // found the 0s
+                        skipBytes = i + sizeof(unsigned short);
+                        break;
+                    }
+                }
+            }
+
+            bytesToCopy -= skipBytes;
+
+            // check if we are the last very last block and we aren't full
+            if(saveSize - bytesWritten < blockDataSize)
+            {
+                // last block isn't full, copy less data
+                bytesToCopy = saveSize - bytesWritten;
+            }
+
+            // at maximum we can only copy blockDataSize at once
+            if(bytesToCopy > blockDataSize)
+            {
+                return -1;
+            }
+
+            // another sanity check
+            if(bytesWritten + bytesToCopy > saveSize)
+            {
+                return -1;
+            }
+
+            memcpy(saveData + bytesWritten, block + skipBytes + SAT_TAG_SIZE, bytesToCopy);
+            bytesWritten += bytesToCopy;
+        }
+
+        ++satBlocks;
+    }
+
+    return 0;
+}
+

--- a/Save-Game-Copier/backends/sat.h
+++ b/Save-Game-Copier/backends/sat.h
@@ -1,0 +1,71 @@
+// Saturn Allocation Table (SAT) save partitions parsing
+#pragma once
+
+//
+// SAT structures
+//
+
+//
+// Saturn saves are stored in 64-byte blocks
+// - the first 4 bytes of each block is a tag
+// -- 0x80000000 = start of new save
+// -- 0x00000000 = continuation block?
+// - the next 30 bytes are metadata for the save (save name, language, comment, date, and size)
+// -- the size is the size of the save data not counting the metadata
+// - next is a variable array of 2-byte block ids. This array ends when 00 00 is encountered
+// -- the block id for the 1st block (the one containing the metadata) is not present. In this case only 00 00 will be present
+// -- the variable length array can be 0-512 elements (assuming max save is on the order of ~32k)
+// -- to complicate matters, the block ids themselves can extend into multiple blocks. This makes computing the block count tricky
+// - following the block ids is the save data itself
+//
+
+#define SAT_PARTITION_SIZE      0x40 // BUGBUG: this should be dynamic
+
+#define SAT_MAX_SAVE_NAME       11
+#define SAT_MAX_SAVE_COMMENT    10
+
+#define SAT_START_BLOCK_TAG     0x80000000 // beginning of a save must start with this
+#define SAT_CONTINUE_BLOCK_TAG  0x0        // all other blocks have a 0 tag
+
+
+#define SAT_TAG_SIZE sizeof(((SAT_START_BLOCK_HEADER *)0)->tag)
+
+// BUGBUG: get rid of this
+#define SAT_BLOCK_USABLE_SIZE 0x40 - 4
+#define SAT_BLOCK_HEADER_SIZE 0x1E
+
+// struct at the beginning of a save block
+#pragma pack(1)
+typedef struct _SAT_START_BLOCK_HEADER
+{
+    unsigned int tag;
+    char saveName[SAT_MAX_SAVE_NAME]; // not necessarily NULL terminated
+    unsigned char language;
+    char comment[SAT_MAX_SAVE_COMMENT]; // not necessarily NULL terminated
+    unsigned int date;
+    unsigned int saveSize; // in bytes
+}SAT_START_BLOCK_HEADER, *PSAT_START_BLOCK_HEADER;
+#pragma pack()
+
+
+#define SAT_START_BLOCK_FLAG         0x1    // first block in the save. It contains SAT_START_BLOCK_HEADER followed by SAT table
+#define SAT_TABLE_BLOCK_FLAG         0x2    // block contains the variable lenght SAT table
+#define SAT_TABLE_END_BLOCK_FLAG     0x4    // block contains the end of the SAT table
+
+// represents a SAT block. Used to find data within a SAT partition
+typedef struct _SAT_BLOCK
+{
+    unsigned int blockNum;  // blockNum is the index into the partition. Multiply by block size
+    unsigned int flags;     // it's possible for a block to have multiple flags at once
+} SAT_BLOCK, *PSAT_BLOCK;
+
+
+// parsing functions
+int calcNumBlocks(unsigned int saveSize, unsigned int blockSize, unsigned int* numSaveBlocks);
+int satListSaves(unsigned char* partitionBuffer, unsigned int partitionSize, unsigned int blockSize, PSAVES saves, unsigned int numSaves);
+int getSaveStartBlock(unsigned char* partitionBuf, unsigned int partitionSize, unsigned int blockSize, char* saveName, PSAT_START_BLOCK_HEADER* metadata);
+int getSATBlocks(unsigned char* partitionBuf, unsigned int partitionSize, unsigned int blockSize, PSAT_START_BLOCK_HEADER metadata, PSAT_BLOCK* satBlocks);
+int readSATFromBlock(unsigned char* partitionBuf, unsigned int partitionSize, unsigned int blockSize, unsigned int currBlock, PSAT_BLOCK satBlocks, unsigned int maxBlocks, unsigned int* numBocks);
+int getSATSave(unsigned char* partitionBuffer, unsigned int partitionSize, unsigned int blockSize, PSAT_BLOCK satTable, unsigned char* saveData, unsigned int saveSize);
+
+

--- a/Save-Game-Copier/backends/satiator.c
+++ b/Save-Game-Copier/backends/satiator.c
@@ -1,0 +1,379 @@
+#include "satiator.h"
+//#include "satiator/satiator.h"
+#include "../../libsatiator/satiator.h"
+// returns true if the backup device is found
+bool satiatorIsBackupDeviceAvailable(int backupDevice)
+{
+    int result;
+
+    if(backupDevice != SatiatorBackup)
+    {
+        return false;
+    }
+
+    result = satiatorEnter();
+    if(result != 0)
+    {
+        // failed to find Satiator
+        return false;
+    }
+
+    // found Satiator
+    return true;
+}
+
+// queries the saves on the Satiator device and fills out the saves array
+// BUGBUG: code copied from satiator-menu/main.c and needs to be under the MPL
+int satiatorListSaveFiles(int backupDevice, PSAVES saves, unsigned int numSaves)
+{
+    int result = 0;
+    unsigned int count = 0;
+    char statbuf[280] = {0};
+    s_stat_t *st = (s_stat_t*)statbuf;
+    int len = 0;
+
+    if(backupDevice != SatiatorBackup)
+    {
+        return -1;
+    }
+    //SaRINGS - have to nop out this functionality as Rings has already set the correct mode and moved to the desired directory
+    // result = satiatorEnter();
+    // if(result != 0)
+    // {
+    //     //displayStatus("Failed to detect satiator");
+    //     return -1;
+    // }
+
+    result = s_opendir(".");
+    if(result != 0)
+    {
+        //displayStatus("readSatiatorSaveFiles: Failed to open SATSAVES directory");
+        return -2;
+    }
+
+    // loop through the files in the directory
+    while ((len = s_stat(NULL, st, sizeof(statbuf)-1)) > 0)
+    {
+        st->name[len] = 0;
+
+        //skip directories
+        if(st->attrib & AM_DIR)
+        {
+            continue;
+        }
+
+        // skip . and .. (and anything beginning with .)
+        if (st->name[0] == '.')
+        {
+            continue;
+        }
+
+        result = isFileBUPExt(st->name);
+        if(result == false)
+        {
+            // not a .BUP file, skip
+            continue;
+        }
+
+        strncpy((char*)saves[count].filename, st->name, MAX_FILENAME);
+        saves[count].filename[MAX_FILENAME - 1] = '\0';
+        saves[count].datasize = st->size - sizeof(BUP_HEADER);
+        saves[count].blocksize = 0; // blocksize on the Satiator doesn't matter
+        count++;
+
+        if(count >= numSaves)
+        {
+            break;
+        }
+    }
+
+    // for each file found, read the BUP header and parse the metadata
+    for(unsigned int i = 0; i < count; i++)
+    {
+        BUP_HEADER bupHeader = {0};
+
+        result = satiatorReadBUPHeader(saves[i].filename, &bupHeader);
+        if(result != 0)
+        {
+            //displayStatus("bup header %s", saves[i].filename);
+            continue;
+        }
+
+        result = parseBupHeaderValues(&bupHeader, saves[count].datasize + sizeof(BUP_HEADER), saves[i].name, saves[i].comment, &saves[i].language, &saves[i].date, &saves[i].datasize, &saves[i].blocksize);
+        if(result != 0)
+        {
+            //displayStatus("Failed with %d", result);
+
+
+            // BUGBUG: handle error conditions gracefully
+            strncpy(saves[i].name, "Error", MAX_SAVE_FILENAME);
+
+            continue;
+        }
+    }
+
+    // BUGBUG: close the directory??
+    return count;
+}
+
+// copies the specified Satiator save game to the saveFileData buffer
+int satiatorReadSaveFile(int backupDevice, char* filename, unsigned char* outBuffer, unsigned int outSize)
+{
+    int result = 0;
+    int fd = 0;
+
+    if(backupDevice != SatiatorBackup)
+    {
+        return -1;
+    }
+
+    //result = satiatorEnter();
+    //if(result == 0)
+    //{
+    //    // why is it failing to detect now??
+    //    ////displayStatus("Failed to detect satiator %d", result);
+    //    //return -1;
+    //}
+
+    if(outBuffer == NULL || filename == NULL)
+    {
+        //displayStatus("readSatiatorSaveFile: Save file data buffer is NULL!!");
+        return -1;
+    }
+
+    if(outSize == 0 || outSize > MAX_SAVE_SIZE)
+    {
+        //displayStatus("readSatiatorSaveFile: Save file size is invalid %d!!", outSize);
+        return -2;
+    }
+
+    fd = s_open(filename, FA_READ);
+    if(fd < 0)
+    {
+        //displayStatus("readSatiatorSaveFile: Failed to open satiator file!!");
+        return -2;
+    }
+
+    for(unsigned int bytesRead = 0; bytesRead < outSize; )
+    {
+        unsigned int count;
+
+        count = MIN(outSize - bytesRead, S_MAXBUF);
+
+        // BUGBUG: fix this
+        result = s_read(fd, outBuffer + bytesRead, count);
+        if(result <= 0)
+        {
+            //displayStatus("Bad read result: %x", result);
+            s_close(fd);
+            return result;
+        }
+
+        bytesRead += count;
+    }
+
+    s_close(fd);
+
+    if(result < 0)
+    {
+        //displayStatus("readSatiatorSaveFile: Failed to read satiator file!!");
+        return -3;
+    }
+
+    return 0;
+}
+
+// write the save game to the Satiator
+int satiatorWriteSaveFile(int backupDevice, char* filename, unsigned char* inBuffer, unsigned int inSize)
+{
+    int result = 0;
+    int fd = 0;
+
+    if(backupDevice != SatiatorBackup)
+    {
+        return -1;
+    }
+
+    //result = satiatorEnter();
+    //if(result != 0)
+    //{
+    //    //displayStatus("Failed to detect satiator");
+    //    return -1;
+    //}
+
+    if(filename == NULL)
+    {
+        //displayStatus("writeSatiatorSaveData: Save file data buffer is NULL!!");
+        return -1;
+    }
+
+    if(inBuffer == NULL || filename == NULL)
+    {
+        //displayStatus("writeSatiatorSaveData: Save file size is invalid %d!!", inSize);
+        return -2;
+    }
+
+    fd = s_open(filename, FA_WRITE|FA_CREATE_ALWAYS);
+    if(fd < 0)
+    {
+        //displayStatus("writeSatiatorSaveData: Failed to open satiator file!!");
+        return -2;
+    }
+
+    for(unsigned int bytesWritten = 0; bytesWritten < inSize; )
+    {
+        unsigned int count;
+
+        count = MIN(inSize - bytesWritten, S_MAXBUF);
+
+        // BUGBUG: fix this
+        result = s_write(fd, inBuffer + bytesWritten, count);
+
+        s_sync(fd);
+
+        if(result <= 0)
+        {
+            //displayStatus("Bad write result: %x", result);
+            s_close(fd);
+            return result;
+            break;
+        }
+
+        bytesWritten += count;
+    }
+
+    s_close(fd);
+
+    if(result < 0)
+    {
+        //displayStatus("writeSatiatorSaveData: Failed to read satiator file!!");
+        return -3;
+    }
+
+    return 0;
+}
+
+// delete the save
+int satiatorDeleteSaveFile(int backupDevice, char* filename)
+{
+    int result = 0;
+
+    if(backupDevice != SatiatorBackup)
+    {
+        return -1;
+    }
+
+    //result = satiatorEnter();
+    //if(result != 0)
+    //{
+    //    //displayStatus("Failed to detect satiator");
+    //    //return -1;
+    //}
+
+    if(filename == NULL)
+    {
+        //displayStatus("deleteSatiatorSaveData: Filename is NULL!!");
+        return -1;
+    }
+
+    result = s_unlink(filename);
+
+    if(result < 0)
+    {
+        //displayStatus("deleteSatiatorSaveData: Failed to read satiator file!!");
+        return -3;
+    }
+
+    return 0;
+}
+
+// enable satiator extra mode
+// without this you cannot access the filesystem
+int satiatorEnter(void)
+{
+    int result;
+
+    result = s_mode(s_api);
+    if(result != 0)
+    {
+        return -1;
+    }
+    //s_chdir("/SATSAVES");
+    return 0;
+}
+
+// exit satiator extra mode
+// BUGBUG: this does not appear to work and ends up with the ISO no longer being accessible
+int satiatorExit(void)
+{
+
+    // BUGBUG: this doesn't quite work correctly
+    //s_chdir("..");
+    //s_mode(S_MODE_CDROM);
+
+    return 0;
+}
+
+// read the bup header
+int satiatorReadBUPHeader(char* filename, PBUP_HEADER bupHeader)
+{
+    int result = 0;
+    int fd = 0;
+    bool openedFile = false;
+
+    if(!filename || !bupHeader)
+    {
+        return -1;
+    }
+
+    fd = s_open(filename, FA_READ);
+    if(fd < 0)
+    {
+        //displayStatus("readSatiatorSaveFile: Failed to open satiator file!!");
+        return -2;
+    }
+
+    // read the .BUP header
+    result = s_read(fd, (unsigned char*)bupHeader, sizeof(BUP_HEADER));
+    if(result <= 0)
+    {
+        //displayStatus("Bad read result: %x", result);
+        result = -3;
+        goto exit;
+    }
+
+    openedFile = true;
+
+    if(result < (int)sizeof(BUP_HEADER))
+    {
+        //displayStatus("bup header is too small");
+        result = -4;
+        goto exit;
+    }
+
+    result = 0;
+
+exit:
+    if(openedFile == true)
+    {
+        s_close(fd);
+    }
+
+    return result;
+}
+
+// relaunch the satiator menu
+void satiatorReboot(void)
+{
+    s_mode(s_api);
+    for (volatile int i=0; i<2000; i++)
+        ;
+
+    int (**bios_get_mpeg_rom)(uint32_t index, uint32_t size, uint32_t addr) = (void*)0x06000298;
+    (*bios_get_mpeg_rom)(2, 2, 0x200000);
+
+    ((void(*)(void))0x200000)();
+
+    // should never get here
+}
+

--- a/Save-Game-Copier/backends/satiator.h
+++ b/Save-Game-Copier/backends/satiator.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "backend.h"
+
+bool satiatorIsBackupDeviceAvailable(int backupDevice);
+int satiatorListSaveFiles(int backupDevice, PSAVES fileSaves, unsigned int numSaves);
+int satiatorReadSaveFile(int backupDevice, char* filename, unsigned char* ouBuffer, unsigned int outBufSize);
+int satiatorWriteSaveFile(int backupDevice, char* filename, unsigned char* saveData, unsigned int saveDataLen);
+int satiatorDeleteSaveFile(int backupDevice, char* filename);
+
+// helper functions
+int satiatorEnter(void);
+int satiatorExit(void);
+int satiatorReadBUPHeader(char* filename, PBUP_HEADER bupHeader);
+void satiatorReboot(void);

--- a/Save-Game-Copier/backends/saturn.c
+++ b/Save-Game-Copier/backends/saturn.c
@@ -1,0 +1,194 @@
+#include "saturn.h"
+
+// queries whether the backup device is present
+bool saturnIsBackupDeviceAvailable(int backupDevice)
+{
+    bool isPresent = false;
+
+    isPresent = jo_backup_mount(backupDevice);
+    if(isPresent == true)
+    {
+        jo_backup_unmount(backupDevice);
+        return true;
+    }
+
+    return false;
+}
+
+// queries the saves on the backup device and fills out the fileSaves array
+int saturnListSaveFiles(int backupDevice, PSAVES saves, unsigned int numSaves)
+{
+    jo_list saveFilenames = {0};
+    bool result = false;
+    int count = 0;
+
+    jo_list_init(&saveFilenames);
+
+    // mount the backup device
+    result = jo_backup_mount(backupDevice);
+    if(result == false)
+    {
+        // Don't need this error message because jo engine already errors
+        //displayStatus("Failed to mount backup device %d!!", backupDevice);
+        return -1;
+    }
+
+    // get a list of files from the backup device
+    result = jo_backup_read_device(backupDevice, &saveFilenames);
+    if(result == false)
+    {
+        jo_list_free_and_clear(&saveFilenames);
+        return -1;
+    }
+
+    for(unsigned int i = 0; i < (unsigned int)saveFilenames.count && i < numSaves; i++)
+    {
+        char comment[MAX_SAVE_COMMENT] = {0};
+        unsigned char language = 0;
+        unsigned int date = 0;
+        unsigned int numBytes = 0;
+        unsigned int numBlocks = 0;
+
+        char* filename = jo_list_at(&saveFilenames, i)->data.ch_arr;
+
+        if(filename == NULL)
+        {
+            //displayStatus("readSaveFiles list is corrupt!!");
+            return -1;
+        }
+
+        // query the save metadata
+        result = jo_backup_get_file_info(backupDevice, filename, comment, &language, &date, &numBytes, &numBlocks);
+        if(result == false)
+        {
+            ////displayStatus("Failed to read file size!!");
+            continue;
+        }
+
+        // fill out the SAVES structure
+        snprintf(saves[i].filename, MAX_FILENAME, "%s.BUP", filename);
+        strncpy(saves[i].name, filename, MAX_SAVE_FILENAME);
+        strncpy(saves[i].comment, (char*)comment, sizeof(comment));
+        saves[i].language = language;
+        saves[i].date = date;
+        saves[i].datasize = numBytes;
+        saves[i].blocksize = numBlocks;
+        count++;
+    }
+
+    jo_list_free_and_clear(&saveFilenames);
+
+    return count;
+}
+
+// copies the specified save gane to the saveFileData buffer
+int saturnReadSaveFile(int backupDevice, char* filename, unsigned char* outBuffer, unsigned int outBufSize)
+{
+    unsigned char* saveData = NULL;
+    PBUP_HEADER temp = NULL;
+    int result = 0;
+
+    if(outBuffer == NULL || filename == NULL)
+    {
+        //displayStatus("Save file data buffer is NULL!!");
+        return -1;
+    }
+
+    if(outBufSize < sizeof(BUP_HEADER) || outBufSize > (MAX_SAVE_SIZE + sizeof(BUP_HEADER)))
+    {
+        //displayStatus("Save file size is invalid %d!!", outBufSize);
+        return -2;
+    }
+    temp = (PBUP_HEADER)outBuffer;
+
+    // read the file from the backup device
+    // jo engine mallocs a buffer for us
+    saveData = jo_backup_load_file_contents(backupDevice, filename, &outBufSize);
+    if(saveData == NULL)
+    {
+        //displayStatus("Failed to read save file!!");
+        return -3;
+    }
+
+    // query the save metadata
+    unsigned int blockSize = 0;
+    result = jo_backup_get_file_info(backupDevice, filename, (char*)&temp->dir.comment, &temp->dir.language, &temp->dir.date, &temp->dir.datasize, &blockSize);
+
+    if(result == false)
+    {
+        //displayStatus("Failed to save metadata  size!!");
+        return -1;
+    }
+    memcpy(temp->magic, VMEM_MAGIC_STRING, VMEM_MAGIC_STRING_LEN);
+    strncpy((char*)temp->dir.filename, filename, MAX_SAVE_FILENAME);
+    temp->date = temp->dir.date; // date is duplicated
+    temp->dir.blocksize = blockSize;
+
+    // copy the save game data and free the jo engine buffer
+    memcpy(outBuffer + sizeof(BUP_HEADER), saveData, outBufSize);
+    jo_free(saveData);
+
+    return 0;
+}
+
+int saturnWriteSaveFile(int backupDevice, char* filename, unsigned char* saveData, unsigned int saveDataLen)
+{
+    bool result = false;
+    PBUP_HEADER temp = NULL;
+    jo_backup saveMeta = {0};
+
+    // BUP header is required
+    if(saveDataLen < sizeof(BUP_HEADER))
+    {
+        //displayStatus("Invalid .BUP header");
+        return -1;
+    }
+
+    temp = (PBUP_HEADER)saveData;
+
+    // mount the backup device
+    result = jo_backup_mount(backupDevice);
+    if(result == false)
+    {
+        //displayStatus("Failed to mount backup device %d!!", backupDevice);
+        return -2;
+    }
+
+    saveMeta.backup_device = backupDevice;
+    saveMeta.fname = filename;
+    saveMeta.comment = (char*)temp->dir.comment;
+    saveMeta.contents = saveData + sizeof(BUP_HEADER);
+    saveMeta.content_size = saveDataLen - sizeof(BUP_HEADER);
+    saveMeta.language_num = temp->dir.language;
+    saveMeta.save_timestamp = temp->dir.date;
+
+    result = jo_backup_save(&saveMeta);
+    if(result == false)
+    {
+        ////displayStatus("Failed to write save backup device %d!!", backupDevice);
+        return -3;
+    }
+
+    return 0;
+}
+
+int saturnDeleteSaveFile(int backupDevice, char* filename)
+{
+    bool result;
+
+    // mount the backup device
+    result = jo_backup_mount(backupDevice);
+    if(result == false)
+    {
+        //displayStatus("Failed to mount backup device %d!!", backupDevice);
+        return -1;
+    }
+
+    result = jo_backup_delete_file(backupDevice, filename);
+    if(result == false)
+    {
+        return -1;
+    }
+
+    return 0;
+}

--- a/Save-Game-Copier/backends/saturn.h
+++ b/Save-Game-Copier/backends/saturn.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "backend.h"
+
+bool saturnIsBackupDeviceAvailable(int backupDevice);
+int saturnListSaveFiles(int backupDevice, PSAVES saves, unsigned int numSaves);
+int saturnReadSaveFile(int backupDevice, char* filename, unsigned char* outBuffer, unsigned int outSize);
+int saturnWriteSaveFile(int backupDevice, char* filename, unsigned char* inBuffer, unsigned int inSize);
+int saturnDeleteSaveFile(int backupDevice, char* filename);
+int saturnFormatDevice(int backupDevice);

--- a/Save-Game-Copier/bup_header.c
+++ b/Save-Game-Copier/bup_header.c
@@ -1,0 +1,247 @@
+#include "bup_header.h"
+
+/*
+ *  Format          void BUP_GetDate(unsigned int date, jo_backup_date *date)
+ *  Input           pdate : data and time data of directory information
+ *                  date : date and time table
+ *  Output          none
+ *  Function value  none
+ *  Function        Expands the date and time data in the directory information table.
+ */
+void bup_getdate(unsigned int date, jo_backup_date *tb)
+{
+    unsigned long div;
+
+    /* Set minute count. */
+    tb->min = (unsigned char)(date % 60);
+
+    /* Set hour. */
+    tb->time = (unsigned char)((date % (60*24)) / 60);
+
+    /* Compute days count. */
+    div = date / (60*24);
+
+    /* Set of week. */
+    if (div > 0xAB71)
+    {
+        tb->week = (unsigned char)((div + 1) % 7);
+    }
+    else
+    {
+        tb->week = (unsigned char)((div + 2) % 7);
+    }
+
+    /* To process leap year, simply consider a pack of 4 years whose first one
+     * is a multiple of 4, and loop up to 48 months until getting remaining
+     * days count fitting into one month.
+     *
+     * It's a bit kind of naive (not to say dumb) implementation, but it works,
+     * and as it's not the kind of routine that require heavy optimization
+     * there's no plan to make this algorithm smarter.
+     */
+    unsigned long year_base   = div / ((365*4) + 1);
+    year_base = year_base * 4;
+    unsigned long days_remain = div % ((365*4) + 1);
+    const char days_count[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+    unsigned char month = 0;
+    int i;
+    for(i=0; i<(4*12); i++)
+    {
+        unsigned char days_per_month = days_count[i % 12];
+        if(i == 1)
+        {
+            days_per_month++;
+        }
+
+        if(days_remain < days_per_month)
+        {
+            break;
+        }
+
+        days_remain -= days_per_month;
+        month++;
+
+        if((i % 12) == 11)
+        {
+            month = 0;
+            year_base++;
+        }
+    }
+
+    tb->month = month + 1;
+    tb->day   = days_remain + 1;
+    tb->year  = year_base;
+
+
+    /* Code below is here to reproduce the same bug as in Saturn BIOS,
+     * so please disable it if you prefer a valid date rather than a
+     * completely equivalent re-implementation.
+     *
+     * Description : 1st January following a leap year is incorrectly
+     *               returned as December 32nd of this leap year.
+     *
+     * Examples :
+     *  >Error2 #  1, BIO:1980/12/32 00:42 4, B:00080AEA
+     *  >           , VMM:1981/01/01 00:42 4
+     *  >           , ORG:1981/01/01 00:42
+     *  >Error2 #  2, BIO:1980/12/32 07:42 4, B:00080C8E
+     *  >           , VMM:1981/01/01 07:42 4
+     *  >           , ORG:1981/01/01 07:42
+     *  >Error2 #  5, BIO:1984/12/32 00:42 2, B:0028250A
+     *  >           , VMM:1985/01/01 00:42 2
+     *  >           , ORG:1985/01/01 00:42
+     *
+     * Note : it is preferable that the implementation here (vmem) should
+     *        return a valid date rather than pushing mimic of BIOS behavior
+     *        including its bugs.
+     */
+#if 0
+    if((tb->month      == 1)
+    && (tb->day        == 1)
+    && ((tb->year % 4) == 1))
+    {
+        tb->month = 12;
+        tb->day   = 32;
+        tb->year--;
+    }
+#endif
+}
+
+/*
+ *  Format          Uint32 BUP_SetDate(BupDate *date)
+ *  Input           date : date and time table
+ *  Output          none
+ *  Function value  Data in date and time data form in the directory information table.
+ *  Function        Compresses the date and time data in the directory information table.
+ */
+unsigned int bup_setdate(jo_backup_date *tb)
+{
+    /* Table of elapsed days per month. */
+    const unsigned short monthtbl[11] =
+    {
+        31,
+        31+28,
+        31+28+31,
+        31+28+31+30,
+        31+28+31+30+31,
+        31+28+31+30+31+30,
+        31+28+31+30+31+30+31,
+        31+28+31+30+31+30+31+31,
+        31+28+31+30+31+30+31+31+30,
+        31+28+31+30+31+30+31+31+30+31,
+        31+28+31+30+31+30+31+31+30+31+30
+    };
+    unsigned long date;
+    unsigned char data;
+    unsigned long remainder;
+
+
+    /* Easter Egg when specified time is set to invalid null values
+     *
+     * Technical details on SegaXtreme forums :
+     *  https://segaxtreme.net/threads/backup-memory-structure.16803/
+     *
+     * antime   : If you take the 1980/0/0 value and go backwards from
+     *            1980/1/1 you get 1963/10/8. I wonder if that's an
+     *            easter egg - the programmer's birthday or something similar.
+     * TascoDLX : The value in question, 0x008246A0, corresponds to
+     *            1996/3/26 0:00, which pretty much coincides with the
+     *            passing of Comet Hyakutake.
+     *            As far as easter eggs go, that'd be my guess.
+     * antime   : The comet wasn't discovered until January 1996.
+     *            That'd be hell of an easter egg...
+     *
+     * Note : in this re-implementation, the value before adding this
+     *        easter egg was : t:0x026CECE0 -> 2057/05/15 00:00
+     *        Probably something caused by random value read outside range,
+     *        or indicating the passing of another new comet ?!
+     */
+    if((tb->year  == 0)
+    && (tb->month == 0)
+    && (tb->day   == 0)
+    && (tb->time  == 0)
+    && (tb->min   == 0))
+    {
+        return 0x008246A0;
+    }
+
+    /* Add year to result. */
+    data = tb->year;
+    date = (data / 4) * 0x5B5; // 0x5B5 = 365.25 * 4
+
+    remainder = data % 4;
+    if(remainder)
+    {
+        date += (remainder * 0x16D) + 1; // 0x16D = 365
+    }
+
+    /* Leap year fix.
+     * Code from Yabause HLE BIOS seems broken regarding leap years support.
+     *
+     * Rather than making a "clean" fix, and also because I'm not smart enough
+     * to understand the "365.25 * 4" code above, date is adjusted in cases
+     * causing problems.
+     *
+     * Additionally, I don't want to spend days in optimizing that : writing
+     * accurate date manipulation routines is some kind of art that may chew
+     * a lot of free time that would be better being dedicated in more
+     * interesting projects.
+     *
+     * Fix is verified under test bench implemented in Save Data Manager's
+     * extra menu which compares result between BIOS and this custom BUP_SetDate
+     * functions, so that it should behave fine in any possible case until 2199.
+     */
+    unsigned short year = 1980 + tb->year;
+    int leap_year;
+    if((year % 4) != 0)
+    {
+        leap_year = 0;
+    }
+    else if((year % 100) != 0)
+    {
+        leap_year = 1;
+    }
+    else if((year % 400) != 0)
+    {
+        leap_year = 0;
+    }
+    else
+    {
+        leap_year = 1;
+    }
+
+    date--;
+    if((leap_year) && (tb->month == 2))
+    {
+        date--;
+    }
+    if((year > 2000) && ((year % 100) == 0) && (tb->month == 2))
+    {
+        date--;
+    }
+
+    /* Add month to result. */
+    data = tb->month;
+    if(data != 1 && data < 13)
+    {
+        date += monthtbl[data - 2];
+        if(date > 2 && remainder == 0)
+        {
+            date++;
+        }
+    }
+
+    /* Add day to result. */
+    date += tb->day;
+    date *= 0x5A0;
+
+    /* Add hour to result. */
+    date += (tb->time * 0x3C);
+
+    /* Add minute to result. */
+    date += tb->min;
+
+    return date;
+}
+

--- a/Save-Game-Copier/bup_header.h
+++ b/Save-Game-Copier/bup_header.h
@@ -1,0 +1,142 @@
+/*
+ * bup_header.h - structure definition for the .BUP file header used
+ * by various Sega Saturn tools.
+ *
+ * Format developed by Cafe-Alpha (https://segaxtreme.net/threads/save-game-metadata-questions.24625/post-178534)
+ *
+ * Date conversion functions taken from Cafe-Alpha's Pseudo Saturn Kai
+ *
+ */
+#pragma once
+
+/** .BUP extension is required to work wih PS Kai */
+#define BUP_EXTENSION ".BUP"
+
+/** The BUP header structure (sizeof(vmem_bup_header_t)) is exactly 64 bytes */
+#define BUP_HEADER_SIZE 64
+
+/** BUP header magic */
+#define VMEM_MAGIC_STRING_LEN 4
+#define VMEM_MAGIC_STRING "Vmem"
+
+/** Max backup filename length */
+#define JO_BACKUP_MAX_FILENAME_LENGTH      (12)
+
+/** Max backup file comment length */
+#define JO_BACKUP_MAX_COMMENT_LENGTH       (10)
+
+/*
+ * Language of backup save in jo_backup_file
+ * taken from Jo Engine backup.c
+ */
+enum jo_backup_language
+{
+    backup_japanese = 0,
+    backup_english = 1,
+    backup_french = 2,
+    backup_deutsch = 3,
+    backup_espanol = 4,
+    backup_italiano = 5,
+};
+
+/**
+ * Backup file metadata information. Taken from Jo Engine.
+ **/
+typedef struct _jo_backup_file
+{
+    unsigned char filename[JO_BACKUP_MAX_FILENAME_LENGTH];
+    unsigned char comment[JO_BACKUP_MAX_COMMENT_LENGTH + 1];
+    unsigned char language; // jo_backup_language
+    unsigned int date;
+    unsigned int datasize;
+    unsigned short blocksize;
+    unsigned short padding;
+} jo_backup_file;
+
+typedef struct _jo_backup_date {
+    unsigned char year;       // year - 1980
+    unsigned char month;
+    unsigned char day;
+    unsigned char time;
+    unsigned char min;
+    unsigned char week;
+} jo_backup_date;
+
+#if defined( __GNUC__ )
+#pragma pack(1)
+#else
+#pragma pack(push,1)
+#endif
+
+/**
+ * Vmem usage statistics structure.
+ * Statistics are reset on each vmem session, ie when Saturn is reset,
+ * or when game calls BUP_Init function.
+ **/
+typedef struct _vmem_bup_stats_t
+{
+    /* Number of times BUP_Dir function is called. */
+    unsigned char dir_cnt;
+
+    /* Number of times BUP_Read function is called. */
+    unsigned char read_cnt;
+
+    /* Number of times BUP_Write function is called. */
+    unsigned char write_cnt;
+
+    /* Number of times BUP_Verify function is called. */
+    unsigned char verify_cnt;
+} vmem_bup_stats_t;
+
+
+/**
+ * Backup data header. Multibyte values are stored as big-endian.
+ **/
+typedef struct _vmem_bup_header_t
+{
+    /* Magic string.
+     * Used in order to verify that file is in vmem format.
+     */
+    char magic[VMEM_MAGIC_STRING_LEN];
+
+    /* Save ID.
+     * "Unique" ID for each save data file, the higher, the most recent.
+     */
+    unsigned int save_id;
+
+    /* Vmem usage statistics. */
+    vmem_bup_stats_t stats;
+
+    /* Unused, kept for future use. */
+    char unused1[8 - sizeof(vmem_bup_stats_t)];
+
+    /* Backup Data Informations Record (34 bytes + 2 padding bytes). */
+    jo_backup_file dir;
+
+    /* Date stamp, in Saturn's BUP library format.
+     * Used in order to verify which save data is the most
+     * recent one when rebuilding index data.
+     * Note #1 : this information is already present in BupDir structure,
+     * but games are setting it, so it may be incorrect (typically, set
+     * to zero).
+     * Note #2 : this date information is the date when Pseudo Saturn Kai
+     * last started, not the time the save was saved, so if information in
+     * dir structure is available, it is more accurate.
+     */
+    unsigned int date;
+
+    /* Unused, kept for future use. */
+    char unused2[8];
+} vmem_bup_header_t, BUP_HEADER, *PBUP_HEADER;
+
+#if defined( __GNUC__ )
+#pragma pack()
+#else
+#pragma pack(pop)
+#endif
+
+//
+// Functions for converting dates
+//
+void bup_getdate(unsigned int date, jo_backup_date *tb);
+unsigned int bup_setdate(jo_backup_date *tb);

--- a/clean.bat
+++ b/clean.bat
@@ -6,6 +6,8 @@ SET PATH=%COMPILER_DIR%\WINDOWS\Other Utilities;%PATH%
 rm -f ./cd/0.bin
 rm -f *.o
 rm -f ./libsatiator/*.o
+rm -f ./Save-Game-Copier/*.o
+rm -f ./Save-Game-Copier/backends/*.o
 rm -f ./satiator/*.o
 rm -f ./satiator/iapetus/disc_format*.o
 rm -f ./satiator/iapetus/*.o

--- a/makefile
+++ b/makefile
@@ -20,6 +20,8 @@ SRCS+=$(wildcard satiator/disc_format/cdparse.c)
 SRCS+=$(wildcard satiator/iapetus/cd/*.c)
 SRCS+=$(wildcard satiator/iapetus/sh2/*.c)
 SRCS+=$(wildcard satiator/iapetus/video/*.c)
+SRCS+=$(wildcard Save-Game-Copier/*.c)
+SRCS+=$(wildcard Save-Game-Copier/backends/*.c)
 JO_ENGINE_SRC_DIR=../../jo_engine
 COMPILER_DIR=../../Compiler
 include $(COMPILER_DIR)/COMMON/jo_engine_makefile

--- a/options_file.c
+++ b/options_file.c
@@ -35,6 +35,9 @@ void initOptions()
             case OPTIONS_SKIP_SPLASH:
                 options[i] = 0;
                 break;
+            case OPTIONS_PERGAME_SAVE:
+                options[i] = 0;
+                break;
             case OPTIONS_COUNT:
                 break;
         }
@@ -85,6 +88,8 @@ void loadOptions(bool firstInit)
                 sscanf(oneline, "desccache=%d", &options[OPTIONS_DESC_CACHE]);
             if(!strncmp(oneline, "skipsplash", 10))
                 sscanf(oneline, "skipsplash=%d", &options[OPTIONS_SKIP_SPLASH]);
+            if(!strncmp(oneline, "pergamesave", 11))
+                sscanf(oneline, "pergamesave=%d", &options[OPTIONS_PERGAME_SAVE]);
             oneline = s_gets(oneline, ONE_LINE_MAX_LEN, fr, &bytes, st->size);
             if(!strncmp(oneline, "[END]", 5))
                 break;
@@ -160,6 +165,9 @@ bool saveOptions()
     s_write(fw, line, strlen(line));
     
     sprintf(line, "skipsplash=%d\r\n", options[OPTIONS_SKIP_SPLASH]);
+    s_write(fw, line, strlen(line));
+
+    sprintf(line, "pergamesave=%d\r\n", options[OPTIONS_PERGAME_SAVE]);
     s_write(fw, line, strlen(line));
 
     s_write(fw, "[THEME]\r\n", 9);

--- a/options_file.h
+++ b/options_file.h
@@ -6,6 +6,7 @@ enum optionsType
     OPTIONS_AUTO_PATCH,
     OPTIONS_DESC_CACHE,
     OPTIONS_SKIP_SPLASH,
+    OPTIONS_PERGAME_SAVE,
     /* end */
     OPTIONS_COUNT
 };

--- a/satiator_functions.c
+++ b/satiator_functions.c
@@ -244,16 +244,15 @@ int satiatorVerifyPatchDescFileImage(const char * curRegion, char * outGameId)
         strcat(checkStr, " ");
     }
     //extract gameid and trim before returning
-    char rawGameId[11];
+    char rawGameId[MAX_SAVE_COMMENT];
     char * firstSpace;
-    int gameIdLength = sizeof(rawGameId);
+    rawGameId[sizeof(rawGameId)-1] = '\0'; //null terminate raw buffer
     s_seek(fp, gameidLoc, SEEK_SET);
     s_read(fp, rawGameId, 10);
-    firstSpace = strchr(rawGameId,' ');
+    firstSpace = strchr(rawGameId,' '); 
     if (firstSpace != NULL) {
-        gameIdLength = firstSpace-rawGameId+1;
+        *firstSpace = '\0'; //null terminate at the first space
     }
-    rawGameId[gameIdLength-1] = '\0';  //null terminate at the first space
     strcpy(outGameId,rawGameId);
 
     s_close(fp);
@@ -334,7 +333,8 @@ enum SATIATOR_ERROR_CODE satiatorPreparePerGameSRAM()
 {
     enum SATIATOR_ERROR_CODE ret;
     
-    centerTextVblank(20, "Backing up current SRAM");
+    centerTextVblank(20, "Backing up current SRAM"); // double vblank to try and address the satiator hanging during sd ops
+    centerTextVblank(20, "Backing up current SRAM"); 
     ret = saveCreateSaveDirectory("_BACKUP");
     if (ret == SATIATOR_WRITE_ERR) 
     {
@@ -356,10 +356,12 @@ enum SATIATOR_ERROR_CODE satiatorPreparePerGameSRAM()
         return ret;
     }
     
+    centerTextVblank(20, "Creating Game Save Directory"); // double vblank to try and address the satiator hanging during sd ops
     centerTextVblank(20, "Creating Game Save Directory");
     ret = saveCreateSaveDirectory(gameId);
     if(ret == SATIATOR_ALREADY_EXISTS) //directory already exists, copy existing BUPs to SRAM
     {
+        centerTextVblank(20, "Directory Exists, Copying Previous Saves To SRAM"); // double vblank to try and address the satiator hanging during sd ops
         centerTextVblank(20, "Directory Exists, Copying Previous Saves To SRAM");
         ret = saveCopySaveDirectoryToInternalMemory(gameId);
         if(ret != SATIATOR_SUCCESS)

--- a/satiator_functions.c
+++ b/satiator_functions.c
@@ -268,12 +268,7 @@ int satiatorVerifyPatchDescFileImage(const char * curRegion, char * outGameId)
         if(options[OPTIONS_PERGAME_SAVE] == 1)
         {
             centerTextVblank(20, "Imaging Per-Game Save Memory to Console");
-            ret = satiatorPreparePerGameSRAM();
-            if(ret != SATIATOR_SUCCESS)
-            {
-                //TODO if we fail to to do pergame saves should we prompt user to continue anyway?
-                while(1);
-            }
+            satiatorPreparePerGameSRAM();
         }
         return 0;
     }

--- a/satiator_functions.h
+++ b/satiator_functions.h
@@ -25,6 +25,7 @@ enum SATIATOR_STATE
     SATIATOR_STATE_NOT_WORKING
 };
 extern char statbuf[280];
+extern char gameId[11];
 
 extern enum SATIATOR_STATE satiatorState;
 extern int satiatorExecutableFilter(dirEntry *entry);
@@ -37,6 +38,7 @@ extern enum SATIATOR_ERROR_CODE satiatorWriteU16(int fd, uint16_t val);
 extern enum SATIATOR_ERROR_CODE satiatorWriteU32(int fd, uint32_t val);
 extern enum SATIATOR_ERROR_CODE satiatorEmulateDesc(char * descfile);
 extern enum SATIATOR_ERROR_CODE satiatorCreateDirectory(char * dir);
+extern enum SATIATOR_ERROR_CODE satiatorPreparePerGameSRAM();
 extern uint16_t satiatorReadU16(int fd);
 extern int satiatorLaunchOriginalMenu();
 extern char * s_gets(char *buf, uint32_t maxsize, int fd, uint32_t *bytesRead, uint32_t totalBytes);

--- a/save_functions.c
+++ b/save_functions.c
@@ -1,0 +1,289 @@
+#include "save_functions.h"
+
+#include "satiator_functions.h"
+
+SAVES g_Saves[MAX_SAVES];
+
+// save name and savefilename are not the same thing
+char saveFilename[MAX_FILENAME]; // file name
+char saveName[MAX_SAVE_FILENAME]; // selected save file name
+char saveComment[MAX_SAVE_COMMENT]; // selected save comment
+unsigned char saveLanguage; // selected save language
+unsigned int saveDate; // selected save date;
+unsigned int saveFileSize; // selected save file size
+PBUP_HEADER saveBupHeader; // the bup header. Immediately following is the saveFileData
+unsigned char* saveFileData; // the raw save data
+
+
+void initSaves()  // initialization routine for Save subsystem currently does not handle errors but if any errors occur the per-game save option should be disabled.
+{
+    enum SAVE_ERROR_CODE ret;
+    // initialize globals
+    jo_memset(g_Saves, 0, sizeof(g_Saves));
+    // theres no point in allocing more than the 32KB limit of the sram. 
+    saveBupHeader = jo_malloc(sizeof(BUP_HEADER) + 32 * 1024);
+    if(saveBupHeader == NULL)
+    {
+        return;
+    }
+    saveFileData = (unsigned char*)(saveBupHeader + 1);
+   
+    ret = saveReadGameIdInInternalMemory(gameId);
+    switch (ret)
+    {
+        case SAVE_ERROR:
+            return;
+        case SAVE_NO_GAMEID_FOUND:
+            // No game id found in the SRAM so these saves are not tied to a game run by Rings
+
+            break;
+        case SAVE_SUCCESS:
+            // a game was running on previous boot and we need to save its SRAM state to its folder.
+
+            // create a savedir in case this is a different card than the one used to boot the game previously
+            saveCreateSaveDirectory(gameId);
+            
+            saveClearSaveDirectory(gameId);
+
+            ret = saveCopyInternalMemoryToSaveDirectory(gameId);
+            if (ret == SATIATOR_WRITE_ERR) 
+            {
+                return;
+            }
+            // now that we've copied over the per-game SRAM contents to its respective dir
+            // clear the SRAM and place back the original values of the SRAM before we ran the game
+            ret = saveClearInternalMemory();
+            if (ret != SAVE_SUCCESS) 
+            {
+                return;
+            }
+            ret = saveCreateSaveDirectory("_BACKUP");
+            if (ret == SATIATOR_WRITE_ERR)
+            {
+                return;
+            }
+            ret = saveCopySaveDirectoryToInternalMemory("_BACKUP");
+            if (ret != SAVE_SUCCESS)
+            {
+                return;
+            }
+            break;
+        default: //should not be possible
+            break;
+    }
+
+    return;
+}
+
+// Create save subdirectory for the provided gameid in the save directory
+// returns success if the gameid provided is empty, otherwise returns satiatorCreateDirectory's error code
+enum SATIATOR_ERROR_CODE saveCreateSaveDirectory(char* gameid) 
+{
+   
+    enum SATIATOR_ERROR_CODE ret = 0;
+    
+    if (gameid[0] != '\0') 
+    {
+        char * savepath = jo_malloc(SAVE_MAXDIRPATHSIZE);
+        strcpy(savepath,SAVE_FOLDERNAME);
+        strcat(savepath,"/");
+        strcat(savepath,gameid);        
+        ret = satiatorCreateDirectory(savepath);
+        jo_free(savepath);
+    }
+    return ret;
+}
+
+// Generic function to copy all saves from one save medium to another. hardcoded to search through a subdirectory based on gameid
+// in the DEFINE'd save directory location. 
+enum SAVE_ERROR_CODE saveBulkCopyBetweenDevices(int sourceDevice, int destinationDevice, char * gameid) 
+{
+    enum SAVE_ERROR_CODE result = SAVE_SUCCESS;
+    int ret;
+    int bytecount = 0; // count of the total transfered bytes in copy operation
+    
+    char savepath[SAVE_MAXDIRPATHSIZE];
+    strcpy(savepath,SAVE_FOLDERNAME);
+    strcat(savepath,"/");
+    strcat(savepath,gameid);     
+    s_chdir(savepath);
+
+    int count = 0;
+    count = listSaveFiles(sourceDevice, g_Saves, COUNTOF(g_Saves));
+    if (count < 0)
+    {
+        result = SAVE_ERROR;
+    }
+    
+    for (int i = 0; i < count; i++)
+    {
+
+        if (!strcmp(g_Saves[i].name,SAVE_MAGICFILENAME))
+        {
+            continue; // we skip the save indicator file itself during copy      
+        }
+        // UGLY CODE WARNING: these explicit checks were done as the SGC code requires a filename
+        //                    instead of save name for files stored on satiator
+        if (sourceDevice == SatiatorBackup) 
+        {
+            ret = readSaveFile(sourceDevice, g_Saves[i].filename, (unsigned char*)saveBupHeader, g_Saves[i].datasize + sizeof(BUP_HEADER));
+        }
+        else
+        {
+            ret = readSaveFile(sourceDevice, g_Saves[i].name, (unsigned char*)saveBupHeader, g_Saves[i].datasize + sizeof(BUP_HEADER));
+        }
+        if (ret != 0) 
+        {
+            continue; // skip any saves that we have issues reading //TODO more descriptive error
+        }
+        bytecount += g_Saves[i].datasize;
+        if (bytecount >= 32 * 1024)
+        {
+            result = SAVE_OUT_OF_SPACE;
+            break;
+        }
+        if (destinationDevice == SatiatorBackup) 
+        {
+            ret = writeSaveFile(destinationDevice, g_Saves[i].filename, (unsigned char*)saveBupHeader, g_Saves[i].datasize + sizeof(BUP_HEADER));
+        }
+        else 
+        {
+            ret = writeSaveFile(destinationDevice, g_Saves[i].name, (unsigned char*)saveBupHeader, g_Saves[i].datasize + sizeof(BUP_HEADER));
+        }
+       
+        if (ret != 0) 
+        {
+            result = SAVE_ERROR;
+            break;
+        }
+    }
+    
+    s_chdir(currentDirectory);
+    return result;
+}
+
+// Deletes all files in a folder
+// This could be done faster by interleaving the list operations loop and the delete call, doing this manually by using satiator calls or 
+enum SAVE_ERROR_CODE saveBulkDeleteDevice(int targetDevice,char * gameid) 
+{
+    enum SAVE_ERROR_CODE result = SAVE_SUCCESS;
+    int ret;
+
+    if (targetDevice == SatiatorBackup)
+    {
+        if (gameid == NULL)
+        {
+            result = SAVE_ERROR; //TODO more descriptive error
+            return result;
+        }
+        char savepath[SAVE_MAXDIRPATHSIZE];
+        strcpy(savepath,SAVE_FOLDERNAME);
+        strcat(savepath,"/");
+        strcat(savepath,gameid);     
+        s_chdir(savepath);
+    }
+
+    int count = 0;
+    count = listSaveFiles(targetDevice, g_Saves, COUNTOF(g_Saves));
+    if (count < 0)
+    {
+        result = SAVE_ERROR;
+    }
+    
+    for (int i = 0; i < count; i++)
+    {
+        
+        
+        if (targetDevice == SatiatorBackup) 
+        {
+            ret = deleteSaveFile(targetDevice,  g_Saves[i].filename);
+        }
+        else
+        {
+            ret = deleteSaveFile(targetDevice, g_Saves[i].name);
+        }
+        if (ret != 0) 
+        {
+            result = SAVE_ERROR;
+            continue; //if we couldnt delete a specific entry report a failure but attempt to 
+        }
+
+    }
+
+    if (targetDevice == SatiatorBackup)
+    {
+        s_chdir(currentDirectory);
+    }
+    return result;
+}
+
+enum SAVE_ERROR_CODE saveClearInternalMemory()
+{
+    return saveBulkDeleteDevice(JoInternalMemoryBackup,NULL);
+}
+
+enum SAVE_ERROR_CODE saveClearSaveDirectory(char * gameid)
+{
+    return saveBulkDeleteDevice(SatiatorBackup,gameid);
+}
+
+enum SAVE_ERROR_CODE saveCopyInternalMemoryToSaveDirectory(char * gameid)
+{
+    return saveBulkCopyBetweenDevices(JoInternalMemoryBackup,SatiatorBackup,gameid);
+}
+
+enum SAVE_ERROR_CODE saveCopySaveDirectoryToInternalMemory(char * gameid)
+{
+    return saveBulkCopyBetweenDevices(SatiatorBackup,JoInternalMemoryBackup,gameid);
+}
+
+enum SAVE_ERROR_CODE saveReadGameIdInInternalMemory(char * gameid)
+{
+    int count = 0;
+    strcpy(gameid,"");
+    count = listSaveFiles(JoInternalMemoryBackup, g_Saves, COUNTOF(g_Saves));
+    if (count < 0)
+    {
+        return SAVE_ERROR;
+    }
+    //Search for a savefile that has the magic filename
+    for (int i = 0; i < count; i++)
+    {
+        //found the save entry
+        if (!strcmp(g_Saves[i].name,SAVE_MAGICFILENAME))
+        {     
+            //extract gameid from the save entry comment metadata
+            strncpy(gameid,g_Saves[i].comment,MAX_SAVE_COMMENT);
+            return SAVE_SUCCESS;
+        }
+    }
+    // did not find it
+    return SAVE_NO_GAMEID_FOUND;
+}
+
+enum SAVE_ERROR_CODE saveSaveGameIdToInternalMemory(char * gameid)
+{
+    int ret;
+    // initialize saveBupHeader and the 1 ""data"" byte
+    jo_memset(saveBupHeader, 0, sizeof(BUP_HEADER)+SAVE_MAGICFILESIZE);
+
+    memcpy(saveBupHeader->magic, VMEM_MAGIC_STRING, VMEM_MAGIC_STRING_LEN);
+    strncpy((char*)saveBupHeader->dir.filename, SAVE_MAGICFILENAME, MAX_SAVE_FILENAME);
+    saveBupHeader->dir.filename[MAX_SAVE_FILENAME - 1] = '\0'; // null termination for the homies <is this needed?>
+
+    strncpy((char*)saveBupHeader->dir.comment,gameid,MAX_SAVE_COMMENT);
+    saveBupHeader->dir.comment[MAX_SAVE_COMMENT - 1] = '\0';
+    saveBupHeader->dir.datasize = SAVE_MAGICFILESIZE; //0x33
+    
+    saveBupHeader->dir.blocksize = 2; // this was the value used by Ultraman in its 0x33 datasize save so i copied that
+    saveBupHeader->dir.language = backup_english;
+    saveBupHeader->dir.date = 0x014BDE33; // Currently set to a random date. Should use this field for future multi save slot designation
+    saveBupHeader->date = saveBupHeader->dir.date;
+    strncpy((char*)saveFileData,"TESTTESTTESTTEST",SAVE_MAGICFILESIZE); // additional metadata about the game and save folder can be stored here
+    ret = writeSaveFile(JoInternalMemoryBackup, SAVE_MAGICFILENAME, (unsigned char*) saveBupHeader, sizeof(BUP_HEADER) + SAVE_MAGICFILESIZE);
+    if (ret != 0)
+    {
+        return SAVE_ERROR;
+    }
+    return SAVE_SUCCESS;
+}

--- a/save_functions.c
+++ b/save_functions.c
@@ -274,11 +274,11 @@ enum SAVE_ERROR_CODE saveSaveGameIdToInternalMemory(char * gameid)
     saveBupHeader->dir.comment[MAX_SAVE_COMMENT - 1] = '\0';
     saveBupHeader->dir.datasize = SAVE_MAGICFILESIZE; //0x33
     
-    saveBupHeader->dir.blocksize = 2; // this was the value used by Ultraman in its 0x33 datasize save so i copied that
+    saveBupHeader->dir.blocksize = SAVE_MAGICBLOCKSIZE; // this was the value used by Ultraman in its 0x33 datasize save so i copied that
     saveBupHeader->dir.language = backup_english;
     saveBupHeader->dir.date = 0x014BDE33; // Currently set to a random date. Should use this field for future multi save slot designation
     saveBupHeader->date = saveBupHeader->dir.date;
-    strncpy((char*)saveFileData,"TESTTESTTESTTEST",SAVE_MAGICFILESIZE); // additional metadata about the game and save folder can be stored here
+    //strncpy((char*)saveFileData,"TESTTESTTESTTEST",SAVE_MAGICFILESIZE); // additional metadata about the game and save folder can be stored here
     ret = writeSaveFile(JoInternalMemoryBackup, SAVE_MAGICFILENAME, (unsigned char*) saveBupHeader, sizeof(BUP_HEADER) + SAVE_MAGICFILESIZE);
     if (ret != 0)
     {

--- a/save_functions.c
+++ b/save_functions.c
@@ -84,12 +84,11 @@ enum SATIATOR_ERROR_CODE saveCreateSaveDirectory(char* gameid)
     
     if (gameid[0] != '\0') 
     {
-        char * savepath = jo_malloc(SAVE_MAXDIRPATHSIZE);
+        char savepath[SAVE_MAXDIRPATHSIZE];
         strcpy(savepath,SAVE_FOLDERNAME);
         strcat(savepath,"/");
         strcat(savepath,gameid);        
         ret = satiatorCreateDirectory(savepath);
-        jo_free(savepath);
     }
     return ret;
 }

--- a/save_functions.c
+++ b/save_functions.c
@@ -134,7 +134,7 @@ enum SAVE_ERROR_CODE saveBulkCopyBetweenDevices(int sourceDevice, int destinatio
         }
         if (ret != 0) 
         {
-            continue; // skip any saves that we have issues reading //TODO more descriptive error
+            continue; 
         }
         bytecount += g_Saves[i].datasize;
         if (bytecount >= 32 * 1024)
@@ -173,7 +173,7 @@ enum SAVE_ERROR_CODE saveBulkDeleteDevice(int targetDevice,char * gameid)
     {
         if (gameid == NULL)
         {
-            result = SAVE_ERROR; //TODO more descriptive error
+            result = SAVE_ERROR; 
             return result;
         }
         char savepath[SAVE_MAXDIRPATHSIZE];

--- a/save_functions.h
+++ b/save_functions.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <jo/jo.h>
+#include "Save-Game-Copier/backends/backend.h"
+
+#define SAVE_FOLDERNAME "/satiator-saves"
+#define SAVE_MAGICFILENAME "SAVRING"
+#define SAVE_MAGICFILESIZE 52
+#define SAVE_MAXDIRPATHSIZE sizeof(SAVE_FOLDERNAME)+MAX_SAVE_COMMENT // the appended slash and null termination byte is accounted for as sizeof and MAX_SAVE_COMMENT include an additional byte for null term
+
+#define COUNTOF(x) sizeof(x)/sizeof(x[0])
+
+enum SAVE_ERROR_CODE
+{
+    SAVE_SUCCESS,
+    SAVE_ERROR,
+    SAVE_NO_GAMEID_FOUND,
+    SAVE_OUT_OF_SPACE
+};
+
+
+extern void initSaves();
+enum SAVE_ERROR_CODE saveBulkCopyBetweenDevices(int sourceDevice, int destinationDevice, char * gameid);
+enum SAVE_ERROR_CODE saveBulkDeleteDevice(int targetDevice,char * gameid);
+extern enum SATIATOR_ERROR_CODE saveCreateSaveDirectory(char * gameid);
+extern enum SAVE_ERROR_CODE saveClearInternalMemory();
+extern enum SAVE_ERROR_CODE saveClearSaveDirectory(char * gameid);
+extern enum SAVE_ERROR_CODE saveCopySaveDirectoryToInternalMemory(char * gameid);
+extern enum SAVE_ERROR_CODE saveCopyInternalMemoryToSaveDirectory(char * gameid);
+extern enum SAVE_ERROR_CODE saveReadGameIdInInternalMemory(char * gameid);
+extern enum SAVE_ERROR_CODE saveSaveGameIdToInternalMemory(char * gameid);

--- a/save_functions.h
+++ b/save_functions.h
@@ -5,7 +5,8 @@
 
 #define SAVE_FOLDERNAME "/satiator-saves"
 #define SAVE_MAGICFILENAME "SAVRING"
-#define SAVE_MAGICFILESIZE 52
+#define SAVE_MAGICFILESIZE 0
+#define SAVE_MAGICBLOCKSIZE 0
 #define SAVE_MAXDIRPATHSIZE sizeof(SAVE_FOLDERNAME)+MAX_SAVE_COMMENT // the appended slash and null termination byte is accounted for as sizeof and MAX_SAVE_COMMENT include an additional byte for null term
 
 #define COUNTOF(x) sizeof(x)/sizeof(x[0])

--- a/states/bootscreen.c
+++ b/states/bootscreen.c
@@ -137,12 +137,7 @@ void logic_bootscreen()
                         if(options[OPTIONS_PERGAME_SAVE] == 1)
                         {
                             centerTextVblank(20, "Imaging Per-Game Save Memory to Console");
-                            ret = satiatorPreparePerGameSRAM();
-                            if(ret != SATIATOR_SUCCESS)
-                            {
-                                //TODO if we fail to to do pergame saves should we prompt user to continue anyway?
-                                while(1);
-                            }
+                            satiatorPreparePerGameSRAM();
                         }
 
                         centerTextVblank(20, "Booting Disc");

--- a/states/bootscreen.c
+++ b/states/bootscreen.c
@@ -5,6 +5,7 @@
 #include "../debug.h"
 #include "routine_states.h"
 #include "../satiator_functions.h"
+#include "../save_functions.h"
 #include "../ini.h"
 #include "../bios.h"
 
@@ -132,6 +133,18 @@ void logic_bootscreen()
                         }
                         centerTextVblank(20, "Adding To Recent History");
                         addItemToRecentHistory();
+                        
+                        if(options[OPTIONS_PERGAME_SAVE] == 1)
+                        {
+                            centerTextVblank(20, "Imaging Per-Game Save Memory to Console");
+                            ret = satiatorPreparePerGameSRAM();
+                            if(ret != SATIATOR_SUCCESS)
+                            {
+                                //TODO if we fail to to do pergame saves should we prompt user to continue anyway?
+                                while(1);
+                            }
+                        }
+
                         centerTextVblank(20, "Booting Disc");
                         ret = satiatorEmulateDesc("emu.desc");
                         if(ret == SATIATOR_PATCH_REQUIRED)

--- a/states/init.c
+++ b/states/init.c
@@ -6,6 +6,7 @@
 #include "routine_states.h"
 #include "../libsatiator/satiator.h"
 #include "../satiator_functions.h"
+#include "../save_functions.h"
 
 enum routine_state_types init_state = ROUTINE_STATE_INITIALIZE;
 
@@ -81,6 +82,7 @@ void logic_init()
         case ROUTINE_STATE_INITIALIZE:
             initOptions();
             initSatiator();
+            initSaves(); 
             load_font_satiator("/satiator-rings/gfx", "FONT.TGA");
             routine_scene = 0;
             init_state = ROUTINE_STATE_RUN;                       

--- a/states/options.c
+++ b/states/options.c
@@ -41,6 +41,11 @@ static char * getOptionName(enum optionsType option, int value)
             return getListTypeName(value);
         case OPTIONS_LIST_CATEGORY:
             return getListCategoryName(value);
+        case OPTIONS_PERGAME_SAVE:
+            if(value == 0)
+                return "Per-Game Saves <Off>";
+            else
+                return "Per-Game Saves <On> ";
         case OPTIONS_SKIP_SPLASH:
             if(value == 0)
                 return "Skip Splash Screen <Off>";
@@ -135,6 +140,7 @@ void logic_options()
                         case OPTIONS_SKIP_SPLASH:
                         case OPTIONS_AUTO_PATCH:
                         case OPTIONS_DESC_CACHE:
+                        case OPTIONS_PERGAME_SAVE:
                             options[selectedMenuOption] += changed;
                             if(options[selectedMenuOption] < 0)
                                 options[selectedMenuOption] = 1;


### PR DESCRIPTION
This is a proof-of-concept change that adds MemCardPro-style per-game dedicated save ram functionality to any games started from Satiator-Rings.

This feature is dependent on @slinga-homebrew's [Save-Game-Copier](https://github.com/slinga-homebrew/Save-Game-Copier) project. In its current state, SGC does not have a lib that can be imported by prospective projects so parts of its codebase have been manually added to the Rings project for this feature. 

### Summary of Operation

- Each game is given a dedicated folder on the SD card that represents its SRAM state. 
- When a game is launched, the original state of the SRAM is saved to the _BACKUP folder.
- The SRAM is cleared.
- If the game has been launched before, the contents of its folder are copied into the SRAM.
- A `SAVRING` marker save file is added to the SRAM that indicates the current game's GameID string. 
- When Rings is launched, the SRAM saves are listed out to search for a marker save. 
- If a marker save is found, the GameID string is used to create a new folder or open existing folder for this game, and replace its current contents with the ones found in the SRAM. 
- Afterwards, Rings erases the SRAM once more and adds all the saves found in the _BACKUP folder to allow users to disable this feature, switch to the legacy satiator menu, or start a CD game with no impact to previous behavior

### Usage Instructions:
#### To use this feature:
1. Enable "Per-Game Saves" in the options pane
2. Launch any title
3. Observe that the title has (almost) the entire 32kb of Internal save memory space available to it.
4. Restart the console back into the rings menu to ensure the per-game saves are stored to the SD card.
#### To play games from CD 
1. If the console was not restarted after the previous gaming session start Rings and ensure you reach the directory listing screen.
2. Place CD into console
3. Restart Console and launch game
4. Observe that the CD title has access to the original state of your internal save memory prior to enabling the per-save feature.
#### To modify per-game saves on the SD card
1. Ensure that all per-game saves have been committed to the SD card by restarting back into Rings  after a previous gaming session.
2. Mount SD card to computer
3. Observe the `satiator-saves` folder and its per-game (denoted by the Sega gameid given to each title) subdirectories.
4. Modify or add additional *.BUP save files to each game while ensuring that each **per-game folder does not go above 32kb**

### Implementation notes and callouts

- The folder and marker names and certain attributes of the marker save's metadata  are in DEFINE's that can be modified to suit tastes and needs. 
- To avoid any compatibility issues, I opted NOT to create a 0 byte SAVE entry and instead used a really small 52 byte save I found an original Title had used. Its not clear to me if this was necessary after all.
- Most of the changes in this feature were isolated to the save* files, but certain changes were made to `satiatorVerifyPatchDescFileImage` to extract the gameID from the CD image along with the region code extraction that was done already. This gameid is set to a global value to match behavior in other parts of Rings
- Satiator-Rings does not currently have an OSS license associated with it and SGC uses GPL3, this discrepancy will need to be resolved
- This is not the most efficient way to do these bulk save operations. I favored using SGC in a clean manner than to modify its codebase and add more efficient bulk operation procedures (such as listing and deleting items in the same loop).
- This save functionality allocates a full 32kb of space in RAM to parse and copy save contents from one device to the other. Even disabling this feature does not currently free this memory (Save init has to occur even if the feature is disabled to ensure we handle certain edge cases)
- Error codes and enum handling could be done better if all error codes in Rings were combined into one enum
- This was tested with a variety of titles over the course of a week, but please exercise caution around saves you care about.

### Future work

- **Clean up Save-Game-Copier dependency**
Save-Game-Copier's codebase had to be heavily commented out and culled to match this feature. To better maintain this codebase, a proposed libSave-Game-Copier would greatly improve maintainability of this feature. The SGC code also had certain changes done to it to ensure it functioned correctly within Rings. This included commenting out of all error and UI code, and removal of Satiator directory change calls (as Rings would perform the correct operations before handing control to SGC)
- **Multiple Save ram slots per-game** 
The SAVRING save file has metadata that can be used to indicate save slot number. UI work would be required to allow users to select between slots.
- **UI to tell users not to shut off their saturns during a save operation that could corrupt sram state**
"If you see this icon, please do not turn off your console as it may lead to data loss"
- **Additional error and diagnosis in the UI** 
This would be useful for explaining to the user if the SRAM or SD card is out of space.
- **If initialization errors occur in the Save subsystem, disable the in-game save feature and direct the user to resolve any issues**
- **Rebootless saves to SD card**
Currently we do not control code execution after the title has been launched. This makes it hard to build a per-game system that ensures writes to the SRAM are copied to the SD card and therefore requires a reboot to commit the changes to disk. However, patching of the game's binary/binaries (certain titles launch multiple executables, US Saturn Bomberman for example) to divert SRAM save logic to instead save directly to the Satiator or a patched AR cart may be possible, but could introduce great compat risk (switching between CD mode and SD card mode while a game is running sounds very risky to me), 
One possible middle ground: a future patched AR cart image could replicate the Save Init functionality so that users wouldn't need to restart into Rings to save their previous session to SD card and reimage their SRAM to _BACKUP state.


